### PR TITLE
Remove incorrect note for Pojomatic

### DIFF
--- a/src/main/java/org/joda/compare/PojomaticPerson.java
+++ b/src/main/java/org/joda/compare/PojomaticPerson.java
@@ -23,8 +23,7 @@ import org.pojomatic.annotations.AutoProperty;
 @AutoProperty
 public final class PojomaticPerson {
   // NOTES
-  // Requires setting up annotation processing
-
+  
   /**
    * The name of the person.
    */


### PR DESCRIPTION
Pojomatic does not require annotation processing to be enabled; it is entirely runtime-based.
